### PR TITLE
Update Terraform AWS Subnet Data Sources Names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_vpc" "rapidpro-vpc" {
 
 data "aws_subnets" "rapidpro" {
   filter {
-    name = "vpc-id"
+    name   = "vpc-id"
     values = [data.aws_vpc.rapidpro-vpc.id]
   }
 }
@@ -60,8 +60,8 @@ module "rapidpro" {
   end_date                   = var.end_date
   alb_bucket_name            = var.alb_bucket_name
   alb_ssl_policy             = var.alb_ssl_policy
-  route53_zone_names          = var.route53_zone_names
-  service_domains             = var.service_domains
+  route53_zone_names         = var.route53_zone_names
+  service_domains            = var.service_domains
   iam_server_ssl_cert        = var.iam_server_ssl_cert
   acm_certificate_domain     = var.acm_certificate_domain
   cnames                     = var.cnames

--- a/main.tf
+++ b/main.tf
@@ -2,8 +2,11 @@ data "aws_vpc" "rapidpro-vpc" {
   id = var.vpc_id
 }
 
-data "aws_subnet_ids" "rapidpro" {
-  vpc_id = data.aws_vpc.rapidpro-vpc.id
+data "aws_subnets" "rapidpro" {
+  filter {
+    name = "vpc-id"
+    values = [data.aws_vpc.rapidpro-vpc.id]
+  }
 }
 
 data "template_file" "init-blue" {
@@ -65,7 +68,7 @@ module "rapidpro" {
   data_bucket_name           = var.data_bucket_name
   iam_s3_user                = var.iam_s3_user
   vpc_id                     = data.aws_vpc.rapidpro-vpc.id
-  subnet_ids                 = length(var.alb_subnet_ids) > 0 ? var.alb_subnet_ids : data.aws_subnet_ids.rapidpro.ids
+  subnet_ids                 = length(var.alb_subnet_ids) > 0 ? var.alb_subnet_ids : data.aws_subnets.rapidpro.ids
   data_bucket_region         = var.data_bucket_region
   create_certificate         = var.create_certificate
   health_check_path          = var.health_check_path
@@ -105,7 +108,7 @@ module "rapidpro-blue" {
   cloudwatch_alarm_actions = var.cloudwatch_alarm_actions
   target_group_arns        = module.rapidpro.target_group_arns
   security_groups          = module.rapidpro.security_groups
-  subnet_ids               = length(var.hosts_subnet_ids) > 0 ? var.hosts_subnet_ids : data.aws_subnet_ids.rapidpro.ids
+  subnet_ids               = length(var.hosts_subnet_ids) > 0 ? var.hosts_subnet_ids : data.aws_subnets.rapidpro.ids
   user_data                = data.template_cloudinit_config.blue.rendered
   ec2_instance_role        = var.ec2_instance_role
 }
@@ -130,7 +133,7 @@ module "rapidpro-green" {
   cloudwatch_alarm_actions = var.cloudwatch_alarm_actions
   target_group_arns        = module.rapidpro.target_group_arns
   security_groups          = module.rapidpro.security_groups
-  subnet_ids               = length(var.hosts_subnet_ids) > 0 ? var.hosts_subnet_ids : data.aws_subnet_ids.rapidpro.ids
+  subnet_ids               = length(var.hosts_subnet_ids) > 0 ? var.hosts_subnet_ids : data.aws_subnets.rapidpro.ids
   user_data                = data.template_cloudinit_config.green.rendered
   ec2_instance_role        = var.ec2_instance_role
 }


### PR DESCRIPTION
`aws_subnet_ids` has been deprecated in favor of `aws_subnets`